### PR TITLE
Plot without Sun.

### DIFF
--- a/elevation.js
+++ b/elevation.js
@@ -472,11 +472,15 @@ function newTarget(t) {
   var uptime = 24 / ctSteps * test.reduce(sum, 0);
   row.uptime = hr2hm(uptime);
 
-  test = t.alt.map(function(x, i) {
-    return (x > 30) * (plot.sun.alt[i] < -18);
-  });
-  var darktime = 24 / ctSteps * test.reduce(sum, 0);
-  row.darktime = hr2hm(darktime);
+  if (plot.sun === undefined) {
+    row.darktime = 0;
+  } else {
+    test = t.alt.map(function(x, i) {
+      return (x > 30) * (plot.sun.alt[i] < -18);
+    });
+    var darktime = 24 / ctSteps * test.reduce(sum, 0);
+    row.darktime = hr2hm(darktime);
+  }
 
   table.row.add(row).draw();
   plot.target(t);


### PR DESCRIPTION
When offline or if Miriade is down, elevation crashes trying to compute darktime.  Set darktime to 0 if the sun is not defined.